### PR TITLE
修改封面存储名为<md5>.jpg，显著减少占用

### DIFF
--- a/lib/services/music_import_service.dart
+++ b/lib/services/music_import_service.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:crypto/crypto.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:audio_metadata_reader/audio_metadata_reader.dart';
 import 'package:drift/drift.dart';
@@ -110,11 +111,19 @@ class MusicImportService {
       if (metadata.pictures.isNotEmpty) {
         final dbFolder = await getApplicationSupportDirectory();
         final picture = metadata.pictures.first;
+
+        // 计算图片内容的MD5哈希
+        final md5Hash = md5.convert(picture.bytes).toString();
+        final fileName = '$md5Hash.jpg';
+
         final albumArtFile = File(
-          p.join(dbFolder.path, '.album_art', '${p.basename(file.path)}.jpg'),
+          p.join(dbFolder.path, '.album_art', fileName),
         );
         await albumArtFile.parent.create(recursive: true);
-        await albumArtFile.writeAsBytes(picture.bytes);
+        // 如果文件已存在则不重复写入
+        if (!await albumArtFile.exists()) {
+          await albumArtFile.writeAsBytes(picture.bytes);
+        }
         albumArtPath = albumArtFile.path;
       }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
       url: https://github.com/GerryDush/audio_service_win.git
       ref: main
   tray_manager: ^0.5.1
+  crypto: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
对于同封面歌曲不再重复存储封面，实测储存占用从500M缩减到100M